### PR TITLE
Add 'buildvcs=false' to builder at build-server in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ test:
 build-server:
 	echo $(PROJECT_ROOT)
 	$(ORDA_BUILDER) "mkdir -p $(BUILD_DIR)"
-	$(ORDA_BUILDER) "cd server && go build -gcflags='all=-N -l' -ldflags '${GO_LDFLAGS}' -o ../$(BUILD_DIR)"
+	$(ORDA_BUILDER) "cd server && go build -buildvcs=false -gcflags='all=-N -l' -ldflags '${GO_LDFLAGS}' -o ../$(BUILD_DIR)"
 
 .PHONY: build-docker-server
 build-docker-server: build-server


### PR DESCRIPTION
### Relevant issues

- Resolved: #49 
- ...

### Checklists

- [ ] New tests created?
- [ ] Related docs updated?

### Description
Add 'buildvcs=false' to builder at build-server in Makefile
